### PR TITLE
feat(ui): tidy footer, remove plausible analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # AI Job Descriptions
+[![Netlify Status](https://api.netlify.com/api/v1/badges/0e7a5679-39cf-4aae-b8d1-34a1941de152/deploy-status)](https://app.netlify.com/projects/jdescriptions/deploys)
 
 A Next.js app that uses AI to describe what different jobs are like day-to-day, what they pay in Texas, and what kind of people enjoy them. Enter a job title and get a detailed breakdown.
 

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -10,20 +10,21 @@ export default function Footer() {
       <div className="container mx-auto">
         <p className="text-gray-500 text-sm text-center">
           Vibed together by{" "}
-          <Link className="text-gray-700 hover:text-gray-900" href="https://luther.io">
+          <Link
+            className="text-gray-700 hover:text-gray-900"
+            href="https://luther.io"
+          >
             Vid Luther and Claude
           </Link>{" "}
           in 2026 <br />
           powered by {aiProvider} model {aiModel}
         </p>
-        <p className="text-gray-500 text-sm text-center"> build info: {version} </p>
+        <p className="text-gray-500 text-sm text-center">
+          {" "}
+          version: {version}{" "}
+        </p>
         <br />
-        <div className="text-blue-500 text-sm text-center">
-          <Link href="https://plausible.io/jd.luther.io?goal=Looked+Up">
-            {" "}
-            Curious what other people searched for? ..{" "}
-          </Link>
-        </div>
+        <div className="text-blue-500 text-sm text-center"></div>
       </div>
     </footer>
   );

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -8,7 +8,6 @@ import Header from "components/Header";
 import ApiResponse from "components/apiResponse";
 
 import { BeakerIcon } from "@heroicons/react/24/solid";
-import { usePlausible } from "next-plausible";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -56,7 +55,6 @@ function oldformatResponse(response) {
 }
 
 export default function Home() {
-  const plausible = usePlausible();
   const [jobTitleIndex, setJobTitleIndex] = useState(0);
   const [jobName, setjobName] = useState("");
   const [result, setResult] = useState();
@@ -151,18 +149,6 @@ export default function Home() {
                 value={jobName}
                 onChange={(e) => setjobName(e.target.value)}
               />
-              <button
-                onClick={() =>
-                  plausible("Looked Up", {
-                    props: { job: jobName },
-                  })
-                }
-                type="submit"
-                value="Look up..."
-                className="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline mb-8"
-              >
-                {isProcessing ? "Looking up..." : "Look it up..."}
-              </button>
             </form>
           </div>
           <BeakerIcon className="h-6 w-6 text-red-500" />


### PR DESCRIPTION
Refactor Footer layout to improve JSX formatting and simplify
displayed build info. Replace the inline "Curious what other
people searched for?" link with an empty placeholder div and
normalize the version line to "version: {version}".

Remove next-plausible usage and related analytics calls from the
home page: delete import, hook invocation, and the button click
that sent "Looked Up" events. Also remove the button that relied
on plausible (the now submits without firing analytics).

Add Netlify deploy badge to README to surface CI/deploy status.

These changes simplify UI markup, remove dependency on Plausible
analytics, and make build/version info clearer.